### PR TITLE
Stack-Based Approach to Detect 132 Pattern

### DIFF
--- a/Sudoku_solver.cpp
+++ b/Sudoku_solver.cpp
@@ -1,0 +1,49 @@
+class Solution {
+public:
+    bool isvalid(vector<vector<char>>& board, int row, int col, char c)
+    {
+        for(int i=0;i<9;i++)
+        {
+            if(board[row][i]==c) return false;
+            if(board[i][col]==c) return false;
+            if(board[3*(row/3) + i/3 ][3*(col/3) + i%3]==c)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+    bool solve(vector<vector<char>>& board)
+    {
+        for(int i=0;i<9;i++)
+        {
+            for(int j=0;j<9;j++)
+            {
+                if(board[i][j]=='.')
+                {
+                    for(int k='1';k<='9';k++)
+                    {
+                        if(isvalid(board, i,j,k))
+                        {
+                            board[i][j]=k;
+                            if(solve(board))
+                            {
+                                return true;
+                            }
+                            else
+                            {
+                                board[i][j]='.';
+                            }
+                        }
+                    }
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+    void solveSudoku(vector<vector<char>>& board) 
+    {
+        solve(board);
+    }
+};

--- a/c++/Stack_Data_Structure/132-Pattern.cpp
+++ b/c++/Stack_Data_Structure/132-Pattern.cpp
@@ -1,0 +1,27 @@
+
+class Solution {
+public:
+    bool find132pattern(vector<int>& nums) 
+    {
+        ios_base::sync_with_stdio(false);
+        cin.tie(0); cout.tie(0);
+        stack<int> st;
+        int n = nums.size();
+        int prev = INT_MIN;  // This keeps track of the '2' in the 132 pattern
+        for (int i = n - 1; i >= 0; i--)
+        {
+            // If nums[i] is less than the last '2' found, return true
+            if (nums[i] < prev) return true;
+            
+            // Update the '2' value by popping from the stack
+            while (!st.empty() && st.top() < nums[i])
+            {
+                prev = st.top();
+                st.pop();
+            }
+            // Push the current element (potential '3') to the stack
+            st.push(nums[i]);
+        }
+        return false;
+    }
+};


### PR DESCRIPTION

### Intuition
We are looking for a subsequence in the array that follows the 132 pattern: a sequence where there exists indices `i < j < k` such that `nums[i] < nums[k] < nums[j]`. The key is to track the largest '2' in the 132 pattern using a stack.

### Approach
1. Traverse the array in reverse (starting from the rightmost element).
2. Use a stack to keep track of potential '3' values in the 132 pattern.
3. Maintain a variable `prev` to store the most recent valid '2' found in the sequence.
4. For each element `nums[i]`, check if it is less than the current `prev` ('2'). If yes, we've found a valid 132 pattern.
5. Update `prev` by popping from the stack, ensuring we always have the largest possible '2'.
6. Push the current element into the stack as a potential '3'.

### Complexity
- **Time complexity**:  
  The time complexity is \( O(n) \), where \( n \) is the size of the input array. Each element is pushed and popped from the stack at most once.
  
- **Space complexity**:  
  The space complexity is \( O(n) \) in the worst case, due to the space used by the stack.
